### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See the example app for more details.
 <\com.materialoverflowcontent.MaterialContentOverflow>
 ```
 
-##Saving Instance State
+## Saving Instance State
 
 Save the instance state is very simple, as follow:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
